### PR TITLE
allow passing funcMap for use in go template

### DIFF
--- a/gotemplate.go
+++ b/gotemplate.go
@@ -38,6 +38,18 @@ func NewGoTemplatePrinter(tmpl string) (ValuePrinter, error) {
 	}, nil
 }
 
+// NewGoTemplatePrinterWithFuncs returns a printer for outputting values in JSON format.
+func NewGoTemplatePrinterWithFuncs(tmpl string, funcMap template.FuncMap) (ValuePrinter, error) {
+	t, err := template.New("template").Funcs(funcMap).Parse(tmpl)
+	if err != nil {
+		return nil, err
+	}
+	return &GoTemplatePrinter{
+		Template: t,
+		raw:      tmpl,
+	}, nil
+}
+
 // Fprint prints a value in JSON format.
 func (p *GoTemplatePrinter) Fprint(w io.Writer, v interface{}) (err error) {
 	defer func() {

--- a/gotemplate_test.go
+++ b/gotemplate_test.go
@@ -15,6 +15,9 @@
 package klo
 
 import (
+	"strconv"
+	"text/template"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
@@ -35,6 +38,47 @@ var _ = Describe("Go template printer", func() {
 		PrinterPass(p, []string{"foo", "bar"}, `foo
 bar
 `)
+	})
+
+})
+
+var _ = Describe("Go template printer with funcs", func() {
+
+	It("gracefully fails on invalid templates", func() {
+		BadPrinter(NewGoTemplatePrinterWithFuncs(`{{oops}}`, nil))
+	})
+
+	It("catches template execution panics", func() {
+		p := GoodPrinter(NewGoTemplatePrinterWithFuncs(`{{"oops"}}`, nil))
+		ExpectWithOffset(1, p.Fprint(nil, nil)).Should(HaveOccurred())
+	})
+
+	It("templates", func() {
+		p := GoodPrinter(NewGoTemplatePrinterWithFuncs(`{{range .}}{{.}}{{println}}{{end}}`, nil))
+		PrinterPass(p, []string{"foo", "bar"}, `foo
+bar
+`)
+	})
+
+	It("gracefully fails for missing template functions", func() {
+		BadPrinter(NewGoTemplatePrinterWithFuncs(`{{range .}}{{ $intValue := atoi . }}{{ add $intValue 1 }}{{end}}`, template.FuncMap{
+			"add": func(a, b int) int {
+				return a + b
+			},
+		}))
+	})
+
+	It("template funcs", func() {
+		p := GoodPrinter(NewGoTemplatePrinterWithFuncs(`{{range .}}{{ $intValue := atoi . }}{{ add $intValue 1 }}{{end}}`, template.FuncMap{
+			"add": func(a, b int) int {
+				return a + b
+			},
+			"atoi": func(s string) int {
+				i, _ := strconv.Atoi(s)
+				return i
+			},
+		}))
+		PrinterPass(p, []string{"10"}, `11`)
 	})
 
 })

--- a/oflag.go
+++ b/oflag.go
@@ -20,6 +20,7 @@ import (
 	"io/ioutil"
 	"os"
 	"strings"
+	"text/template"
 )
 
 // Specs specifies custom-column formats for the default columns in
@@ -35,6 +36,8 @@ type Specs struct {
 	// and "go-template-file". For "go-template" the arg contains the
 	// template, for "go-template-file" it contains the template filename.
 	GoTemplateArg string
+	// optional any functions to be made available in go template"
+	GoTemplateFuncMap template.FuncMap
 }
 
 // PrinterFromFlag returns a suitable value printer according to the output
@@ -77,9 +80,9 @@ func PrinterFromFlag(flagvalue string, specs *Specs) (ValuePrinter, error) {
 		return NewCustomColumnsPrinterFromTemplate(f)
 	case "go-template":
 		if specs.GoTemplateArg == "" && len(ov) == 2 {
-			return NewGoTemplatePrinter(ov[1])
+			return NewGoTemplatePrinterWithFuncs(ov[1], specs.GoTemplateFuncMap)
 		}
-		return NewGoTemplatePrinter(specs.GoTemplateArg)
+		return NewGoTemplatePrinterWithFuncs(specs.GoTemplateArg, specs.GoTemplateFuncMap)
 	case "go-template-file":
 		tplfn := specs.GoTemplateArg
 		if tplfn == "" && len(ov) == 2 {
@@ -89,7 +92,7 @@ func PrinterFromFlag(flagvalue string, specs *Specs) (ValuePrinter, error) {
 		if err != nil {
 			return nil, err
 		}
-		return NewGoTemplatePrinter(string(tpl))
+		return NewGoTemplatePrinterWithFuncs(string(tpl), specs.GoTemplateFuncMap)
 	case "json":
 		return NewJSONPrinter()
 	case "jsonpath":


### PR DESCRIPTION
Go templates allow passing functions which can then be referenced in the template to perform certain operations.

This PR adds an optional field `GoTemplateFuncMap` to `klo.Specs` which can used to pass a set of functions that can be used in template file.

```go
printSpecs := klo.Specs{
				DefaultColumnSpec: "ID:{.id},START:{.startTime},END:{.endTime}",
				WideColumnSpec:    "ID:{.id},STATUS:{.status},START:{.startTime},END:{.endTime},NAME:{.name}",
				GoTemplateArg:     tpl,
				GoTemplateFuncMap: template.FuncMap{
					"parse": time.Parse,
					"atof": func(s string) float64 {
						i, _ := strconv.ParseFloat(s, 64)
						return i
					},
					"div": func(a, b float64) float64 {
						return a / b
					},
				},
			}
```

These functions would then be usable in templates to allow parsing dates for example or to format dates as per requirement or to perform some arithmetic operations.

```go
{{range .}}
{{- $date1 := parse "2006-01-02T15:04:05Z07:00" .StartTime -}}
{{- $date2 := parse "2006-01-02T15:04:05Z07:00" .EndTime -}}
{{- $diff := $date2.Sub $date1 -}}
ID: {{.Id}} 
Start: {{ $date1.Format "January 2, 2006" }} 
End: {{ $date2.Format "January 2, 2006" }}
Duration: {{ $diff.Hours | printf "%.0f" }} hours or {{ div $diff.Hours 24 | printf "%.1f" }} days
```

Implements #6 